### PR TITLE
Limit numpy when using scikit-umfpack

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,8 @@ requirements:
     - pydantic
     - scipy
     - stats_arrays
-    - numpy <2 # [not (osx and arm64)]
-    - numpy <=1.24 # [osx and arm64]
+    - numpy <2  # [not (osx and arm64)]
+    - numpy <=1.24  # [osx and arm64]
     - pypardiso  # [not (osx and arm64)]
     - scikit-umfpack  # [osx and arm64]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 2
   skip: true  # [py<39]
 
 requirements:
@@ -27,11 +27,12 @@ requirements:
     - bw_processing >=0.9.5
     - json-logging
     - matrix_utils >=0.4.3
-    - numpy <2
     - pandas
     - pydantic
     - scipy
     - stats_arrays
+    - numpy <2 # [not (osx and arm64)]
+    - numpy <=1.24 # [osx and arm64]
     - pypardiso  # [not (osx and arm64)]
     - scikit-umfpack  # [osx and arm64]
 


### PR DESCRIPTION
The release version of `scikit-umfpack` on pypi is 0.4.1, but this hasn't been successfully packaged for `conda-forge` yet; 0.3.3 includes a line `from numpy.testing import Tester`, which breaks on numpy 1.26.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
